### PR TITLE
Add tare() method, fix minor README error

### DIFF
--- a/Adafruit_HX711.cpp
+++ b/Adafruit_HX711.cpp
@@ -98,6 +98,29 @@ int32_t Adafruit_HX711::readChannelRaw(hx711_chanGain_t chanGain) {
 bool Adafruit_HX711::isBusy() { return digitalRead(_dataPin) == HIGH; }
 
 /**
+ * @brief Perform a 'tare' operation
+ * This function reads the sensor 'tareSize' times and calculates the average
+ * value to use as the 'tare' offset
+ *
+ * @param readings Number of readings to average for the tare offset
+ */
+void Adafruit_HX711::tare(uint8_t readings, hx711_chanGain_t chanGain) {
+  // Set the gain
+  readChannelRaw(chanGain);
+
+  int64_t sum = 0;
+  for (uint16_t i = 0; i < readings; i++) {
+    sum += readChannelRaw(chanGain);
+  }
+
+  if (chanGain == CHAN_B_GAIN_32) {
+    _tareValueB = sum / readings;
+  } else {
+    _tareValueA = sum / readings;
+  }
+}
+
+/**
  * @brief Set the raw 'tare' offset for channel A
  * @param tareValue Signed i32 that is added to channel A readings
  */

--- a/Adafruit_HX711.h
+++ b/Adafruit_HX711.h
@@ -22,6 +22,7 @@ public:
   int32_t readChannel(hx711_chanGain_t chanGain = CHAN_A_GAIN_128);
   int32_t readChannelRaw(hx711_chanGain_t chanGain = CHAN_A_GAIN_128);
   int32_t readChannelBlocking(hx711_chanGain_t chanGain = CHAN_A_GAIN_128);
+  void tare(uint8_t tareSize = 10, hx711_chanGain_t chanGain = CHAN_A_GAIN_128);
   void tareA(int32_t tareValue);
   void tareB(int32_t tareValue);
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This is the Adafruit HX711 24-bit ADC library
 
 Tested and works great with the Adafruit HX711 Breakout Board: https://www.adafruit.com/product/XXXX
 
-This chip uses pseudo-SPI to communicate, ay 2 pins are required to interface
+This chip uses pseudo-SPI to communicate, any 2 pins are required to interface
 
 Adafruit invests time and resources providing this open source code, please support Adafruit and open-source hardware by purchasing products from Adafruit!
 
-Written by Limor Fried for Adafruit Industries.  
+Written by Limor Fried for Adafruit Industries.
 MIT license, check license.txt for more information
 All text above must be included in any redistribution
 

--- a/examples/HX711_test/HX711_test.ino
+++ b/examples/HX711_test/HX711_test.ino
@@ -19,15 +19,11 @@ void setup() {
   // Initialize the HX711
   hx711.begin();
 
-  // read and toss 3 values each
+  // tare each channel
   Serial.println("Tareing....");
-  for (uint8_t t=0; t<3; t++) {
-    hx711.tareA(hx711.readChannelRaw(CHAN_A_GAIN_128));
-    hx711.tareA(hx711.readChannelRaw(CHAN_A_GAIN_128));
-    hx711.tareB(hx711.readChannelRaw(CHAN_B_GAIN_32));
-    hx711.tareB(hx711.readChannelRaw(CHAN_B_GAIN_32));
-  }
-} 
+  hx711.tare(10, CHAN_A_GAIN_128);
+  hx711.tare(10, CHAN_B_GAIN_32);
+}
 
 void loop() {
   // Read from Channel A with Gain 128, can also try CHAN_A_GAIN_64 or CHAN_B_GAIN_32

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit HX711
-version=1.0.0
+version=1.0.1
 author=Adafruit <info@adafruit.com>
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the Adafruit HX711 ADC Breakout


### PR DESCRIPTION
Hello,

I have updated the library code to add a "tare" function. This method accepts a number of readings and channel gain as optional parameters, with 10 readings and a gain of "CHAN_A_GAIN_128" as the defaults. It is designed to simplify the tare process, especially for users with multiple HX711s. Also, I fixed what I believe was a small spelling mistake in the README.

There should be no limitations with my change.

Finally, I also modified the example file ("HX711_test.ino") to utilize the new tare method. Note that although the parameters are optional, I specified the values in the test so show the functionality. I have also tested this in another project with no issues.

Thanks,
Christian